### PR TITLE
Update to new record builder syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ main =
             Task.err (Exit 1 "")
 
 cliParser =
-    Cli.weave {
-        alpha: <- Opt.u64 { short: "a", help: "Set the alpha level." },
-        force: <- Opt.flag { short: "f", help: "Force the task to complete." },
-        file: <- Param.maybeStr { name: "file", help: "The file to process." },
-        files: <- Param.strList { name: "files", help: "The rest of the files." },
+    { Cli.weave <-
+        alpha: Opt.u64 { short: "a", help: "Set the alpha level." },
+        force: Opt.flag { short: "f", help: "Force the task to complete." },
+        file: Param.maybeStr { name: "file", help: "The file to process." },
+        files: Param.strList { name: "files", help: "The rest of the files." },
     }
     |> Cli.finish {
         name: "basic",

--- a/examples/default-values.roc
+++ b/examples/default-values.roc
@@ -8,6 +8,7 @@ import pf.Arg
 import pf.Task exposing [Task]
 import weaver.Opt
 import weaver.Cli
+import weaver.Param
 
 main =
     args = Arg.list!
@@ -24,10 +25,14 @@ main =
             Task.err (Exit 1 "")
 
 cliParser =
-    Opt.u64 { short: "a", long: "alpha", help: "Set the alpha level." }
-    |> Cli.map Alpha
+    { Cli.weave <-
+        alpha: Opt.maybeU64 { short: "a", long: "alpha", help: "Set the alpha level. [default: 123]" }
+        |> Cli.map \a -> Result.withDefault a 123,,
+        file: Param.maybeStr { name: "file", help: "The file to process. [default: NONE]" }
+        |> Cli.map \f -> Result.withDefault f "NONE",
+    }
     |> Cli.finish {
-        name: "single-arg",
+        name: "default-values",
         version: "v0.0.1",
     }
     |> Cli.assertValid

--- a/examples/single-arg.roc
+++ b/examples/single-arg.roc
@@ -8,7 +8,6 @@ import pf.Arg
 import pf.Task exposing [Task]
 import weaver.Opt
 import weaver.Cli
-import weaver.Param
 
 main =
     args = Arg.list!
@@ -25,12 +24,8 @@ main =
             Task.err (Exit 1 "")
 
 cliParser =
-    { Cli.weave <-
-        alpha: Opt.u64 { short: "a", help: "Set the alpha level." },
-        force: Opt.flag { short: "f", help: "Force the task to complete." },
-        file: Param.maybeStr { name: "file", help: "The file to process." },
-        files: Param.strList { name: "files", help: "The rest of the files." },
-    }
+    Opt.u64 { short: "a", long: "alpha", help: "Set the alpha level." }
+    |> Cli.map Alpha
     |> Cli.finish {
         name: "basic",
         version: "v0.0.1",

--- a/examples/subcommands.roc
+++ b/examples/subcommands.roc
@@ -26,11 +26,11 @@ main =
             Task.err (Exit 1 "")
 
 cliParser =
-    Cli.weave {
-        force: <- Opt.flag { short: "f", help: "Force the task to complete." },
-        sc: <- Subcommand.optional [subcommandParser1, subcommandParser2],
-        file: <- Param.maybeStr { name: "file", help: "The file to process." },
-        files: <- Param.strList { name: "files", help: "The rest of the files." },
+    { Cli.weave <-
+        force: Opt.flag { short: "f", help: "Force the task to complete." },
+        sc: Subcommand.optional [subcommandParser1, subcommandParser2],
+        file: Param.maybeStr { name: "file", help: "The file to process." },
+        files: Param.strList { name: "files", help: "The rest of the files." },
     }
     |> Cli.finish {
         name: "subcommands",
@@ -41,17 +41,16 @@ cliParser =
     |> Cli.assertValid
 
 subcommandParser1 =
-    Cli.weave {
-        d: <- Opt.maybeU64 { short: "d", help: "A non-overlapping subcommand flag with s2." },
-        volume: <- Opt.maybeU64 { short: "v", long: "volume", help: "How loud to grind the gears." },
-        sc: <- Subcommand.optional [subSubcommandParser1, subSubcommandParser2],
+    { Cli.weave <-
+        d: Opt.maybeU64 { short: "d", help: "A non-overlapping subcommand flag with s2." },
+        volume: Opt.maybeU64 { short: "v", long: "volume", help: "How loud to grind the gears." },
+        sc: Subcommand.optional [subSubcommandParser1, subSubcommandParser2],
     }
     |> Subcommand.finish { name: "s1", description: "A first subcommand.", mapper: S1 }
 
 subcommandParser2 =
-    Cli.weave {
-        d: <- Opt.maybeU64 { short: "d", help: "This doesn't overlap with s1's -d flag." },
-    }
+    Opt.maybeU64 { short: "d", help: "This doesn't overlap with s1's -d flag." }
+    |> Cli.map DFlag
     |> Subcommand.finish {
         name: "s2",
         description: "Another subcommand.",
@@ -59,16 +58,16 @@ subcommandParser2 =
     }
 
 subSubcommandParser1 =
-    Cli.weave {
-        a: <- Opt.u64 { short: "a", help: "An example short flag for a sub-subcommand." },
-        b: <- Opt.u64 { short: "b", help: "Another example short flag for a sub-subcommand." },
+    { Cli.weave <-
+        a: Opt.u64 { short: "a", help: "An example short flag for a sub-subcommand." },
+        b: Opt.u64 { short: "b", help: "Another example short flag for a sub-subcommand." },
     }
     |> Subcommand.finish { name: "ss1", description: "A sub-subcommand.", mapper: SS1 }
 
 subSubcommandParser2 =
-    Cli.weave {
-        a: <- Opt.u64 { short: "a", help: "Set the alpha level." },
-        c: <- Opt.u64 { short: "c", long: "create", help: "Create a doohickey." },
-        data: <- Param.str { name: "data", help: "Data to manipulate." },
+    { Cli.weave <-
+        a: Opt.u64 { short: "a", help: "Set the alpha level." },
+        c: Opt.u64 { short: "c", long: "create", help: "Create a doohickey." },
+        data: Param.str { name: "data", help: "Data to manipulate." },
     }
     |> Subcommand.finish { name: "ss2", description: "Another sub-subcommand.", mapper: SS2 }

--- a/package/Builder.roc
+++ b/package/Builder.roc
@@ -3,12 +3,15 @@ module [
     GetParamsAction,
     StopCollectingAction,
     CliBuilder,
-    fromState,
-    addOptions,
-    addParameters,
+    fromArgParser,
+    fromFullParser,
+    addOption,
+    addParameter,
     addSubcommands,
     updateParser,
     bindParser,
+    map,
+    combine,
     intoParts,
     checkForHelpAndVersion,
 ]
@@ -18,6 +21,7 @@ import Base exposing [
     ArgParserState,
     ArgParserResult,
     onSuccessfulArgParse,
+    mapSuccessfullyParsed,
     ArgExtractErr,
     OptionConfig,
     helpOption,
@@ -31,35 +35,49 @@ GetOptionsAction : { getOptions : {} }
 GetParamsAction : { getParams : {} }
 StopCollectingAction : []
 
-CliBuilder state action := {
-    parser : ArgParser state,
+CliBuilder data fromAction toAction := {
+    parser : ArgParser data,
     options : List OptionConfig,
     parameters : List ParameterConfig,
     subcommands : Dict Str SubcommandConfig,
 }
 
-fromState : base -> CliBuilder base GetOptionsAction
-fromState = \base ->
+fromArgParser : (List Arg -> Result { data : data, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder data fromAction toAction
+fromArgParser = \parser ->
+    newParser = \{ args, subcommandPath } ->
+        when parser args is
+            Ok { data, remainingArgs } -> SuccessfullyParsed { data, remainingArgs, subcommandPath }
+            Err err -> IncorrectUsage err { subcommandPath }
+
     @CliBuilder {
-        parser: \{ args, subcommandPath } -> SuccessfullyParsed { data: base, remainingArgs: args, subcommandPath },
+        parser: newParser,
         options: [],
         parameters: [],
         subcommands: Dict.empty {},
     }
 
-addOptions : CliBuilder state action, List OptionConfig -> CliBuilder state action
-addOptions = \@CliBuilder builder, newOptions ->
-    @CliBuilder { builder & options: List.concat builder.options newOptions }
+fromFullParser : ArgParser data -> CliBuilder data fromAction toAction
+fromFullParser = \parser ->
+    @CliBuilder {
+        parser,
+        options: [],
+        parameters: [],
+        subcommands: Dict.empty {},
+    }
 
-addParameters : CliBuilder state action, List ParameterConfig -> CliBuilder state action
-addParameters = \@CliBuilder builder, newParameters ->
-    @CliBuilder { builder & parameters: List.concat builder.parameters newParameters }
+addOption : CliBuilder state fromAction toAction, OptionConfig -> CliBuilder state fromAction toAction
+addOption = \@CliBuilder builder, newOption ->
+    @CliBuilder { builder & options: List.append builder.options newOption }
 
-addSubcommands : CliBuilder state action, Dict Str SubcommandConfig -> CliBuilder state action
+addParameter : CliBuilder state fromAction toAction, ParameterConfig -> CliBuilder state fromAction toAction
+addParameter = \@CliBuilder builder, newParameter ->
+    @CliBuilder { builder & parameters: List.append builder.parameters newParameter }
+
+addSubcommands : CliBuilder state fromAction toAction, Dict Str SubcommandConfig -> CliBuilder state fromAction toAction
 addSubcommands = \@CliBuilder builder, newSubcommands ->
     @CliBuilder { builder & subcommands: Dict.insertAll builder.subcommands newSubcommands }
 
-setParser : CliBuilder state action, ArgParser nextState -> CliBuilder nextState nextAction
+setParser : CliBuilder state fromAction toAction, ArgParser nextState -> CliBuilder nextState fromAction toAction
 setParser = \@CliBuilder builder, parser ->
     @CliBuilder {
         options: builder.options,
@@ -68,7 +86,7 @@ setParser = \@CliBuilder builder, parser ->
         parser,
     }
 
-updateParser : CliBuilder state action, ({ data : state, remainingArgs : List Arg } -> Result { data : nextState, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder nextState nextAction
+updateParser : CliBuilder state fromAction toAction, ({ data : state, remainingArgs : List Arg } -> Result { data : nextState, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder nextState fromAction toAction
 updateParser = \@CliBuilder builder, updater ->
     newParser =
         { data, remainingArgs, subcommandPath } <- onSuccessfulArgParse builder.parser
@@ -79,7 +97,7 @@ updateParser = \@CliBuilder builder, updater ->
 
     setParser (@CliBuilder builder) newParser
 
-bindParser : CliBuilder state action, (ArgParserState state -> ArgParserResult (ArgParserState nextState)) -> CliBuilder nextState nextAction
+bindParser : CliBuilder state fromAction toAction, (ArgParserState state -> ArgParserResult (ArgParserState nextState)) -> CliBuilder nextState fromAction toAction
 bindParser = \@CliBuilder builder, updater ->
     newParser : ArgParser nextState
     newParser =
@@ -89,7 +107,7 @@ bindParser = \@CliBuilder builder, updater ->
     setParser (@CliBuilder builder) newParser
 
 intoParts :
-    CliBuilder state action
+    CliBuilder state fromAction toAction
     -> {
         parser : ArgParser state,
         options : List OptionConfig,
@@ -97,6 +115,42 @@ intoParts :
         subcommands : Dict Str SubcommandConfig,
     }
 intoParts = \@CliBuilder builder -> builder
+
+map : CliBuilder a fromAction toAction, (a -> b) -> CliBuilder b fromAction toAction
+map = \@CliBuilder builder, mapper ->
+    combinedParser = \input ->
+        builder.parser input
+        |> mapSuccessfullyParsed \{ data, remainingArgs, subcommandPath } ->
+            { data: mapper data, remainingArgs, subcommandPath }
+
+    @CliBuilder {
+        parser: combinedParser,
+        options: builder.options,
+        parameters: builder.parameters,
+        subcommands: builder.subcommands,
+    }
+
+combine : CliBuilder a action1 action2, CliBuilder b action2 action3, (a, b -> c) -> CliBuilder c action1 action3
+combine = \@CliBuilder left, @CliBuilder right, combiner ->
+    combinedParser = \input ->
+        when left.parser input is
+            ShowVersion -> ShowVersion
+            ShowHelp sp -> ShowHelp sp
+            IncorrectUsage argExtractErr sp -> IncorrectUsage argExtractErr sp
+            SuccessfullyParsed { data, remainingArgs, subcommandPath } ->
+                when right.parser { args: remainingArgs, subcommandPath } is
+                    ShowVersion -> ShowVersion
+                    ShowHelp sp -> ShowHelp sp
+                    IncorrectUsage argExtractErr sp -> IncorrectUsage argExtractErr sp
+                    SuccessfullyParsed { data: data2, remainingArgs: restOfArgs, subcommandPath: nextSp } ->
+                        SuccessfullyParsed { data: combiner data data2, remainingArgs: restOfArgs, subcommandPath: nextSp }
+
+    @CliBuilder {
+        parser: combinedParser,
+        options: List.concat left.options right.options,
+        parameters: List.concat left.parameters right.parameters,
+        subcommands: Dict.insertAll left.subcommands right.subcommands,
+    }
 
 flagWasPassed : OptionConfig, List Arg -> Bool
 flagWasPassed = \option, args ->
@@ -107,7 +161,7 @@ flagWasPassed = \option, args ->
             Long long -> long.name == option.long
             Parameter _p -> Bool.false
 
-checkForHelpAndVersion : CliBuilder state action -> CliBuilder state action
+checkForHelpAndVersion : CliBuilder state fromAction toAction -> CliBuilder state fromAction toAction
 checkForHelpAndVersion = \@CliBuilder builder ->
     newParser = \{ args, subcommandPath } ->
         when builder.parser { args, subcommandPath } is
@@ -130,15 +184,15 @@ checkForHelpAndVersion = \@CliBuilder builder ->
 
 expect
     { parser } =
-        fromState (\x -> { x })
-        |> updateParser \{ data, remainingArgs } -> Ok { data: data (Inspect.toStr remainingArgs), remainingArgs: [] }
+        fromArgParser \args -> Ok { data: Inspect.toStr args, remainingArgs: [] }
+        |> map Inspected
         |> intoParts
 
     out = parser { args: [Parameter "123"], subcommandPath: [] }
 
     out
     == SuccessfullyParsed {
-        data: { x: "[(Parameter \"123\")]" },
+        data: Inspected "[(Parameter \"123\")]",
         remainingArgs: [],
         subcommandPath: [],
     }

--- a/package/CliTest.roc
+++ b/package/CliTest.roc
@@ -4,16 +4,15 @@ import Opt
 import Cli
 
 basicCli =
-    Cli.weave {
-        a: <- Opt.u64 { short: "a", help: "Set the alpha level." },
-    }
+    Opt.u64 { short: "a", help: "Set the alpha level." }
+    |> Cli.map Alpha
     |> Cli.finish { name: "basic-cli", version: "v1.0.0", textStyle: Plain }
     |> Cli.assertValid
 
 expect
     basicCli
     |> Cli.parseOrDisplayMessage ["basic-cli", "-a", "123"]
-    == Ok { a: 123 }
+    == Ok (Alpha 123)
 
 expect
     helpMessage =

--- a/package/Help.roc
+++ b/package/Help.roc
@@ -64,9 +64,7 @@ findSubcommand = \command, path ->
 ##
 ## ```roc
 ## exampleCli =
-##     Cli.weave {
-##         verbosity: <- Opt.count { short: "v", help: "How verbose our logs should be." },
-##     }
+##     Opt.count { short: "v", help: "How verbose our logs should be." }
 ##     |> Cli.finish {
 ##         name: "example",
 ##         version: "v0.1.0",
@@ -160,9 +158,7 @@ helpText = \baseConfig, path, textStyle ->
 ##
 ## ```roc
 ## exampleCli =
-##     Cli.weave {
-##         verbosity: <- Opt.count { short: "v", help: "How verbose our logs should be." },
-##     }
+##     Opt.count { short: "v", help: "How verbose our logs should be." }
 ##     |> Cli.finish {
 ##         name: "example",
 ##         version: "v0.1.0",

--- a/package/Opt.roc
+++ b/package/Opt.roc
@@ -111,14 +111,12 @@ getMaybeValue = \values, option ->
 ##             other -> Err (InvalidValue "'$(other)' is not a valid color, must be green, red, or blue")
 ##
 ##     { parser } =
-##         Cli.weave {
-##             color: <- Opt.single { short: "c", parser: parseColor, type: "color" },
-##         }
+##         Opt.single { short: "c", parser: parseColor, type: "color" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-c", "green"]
-##     == SuccessfullyParsed { answer: Green }
+##     == SuccessfullyParsed Green
 ## ```
 single : OptionConfigParams a -> CliBuilder a GetOptionsAction GetOptionsAction
 single = \{ parser, type, short ? "", long ? "", help ? "" } ->
@@ -160,14 +158,12 @@ single = \{ parser, type, short ? "", long ? "", help ? "" } ->
 ##             other -> Err (InvalidValue "'$(other)' is not a valid color, must be green, red, or blue")
 ##
 ##     { parser } =
-##         Cli.weave {
-##             color: <- Opt.maybe { short: "c", type: "color", parser: parseColor },
-##         }
+##         Opt.maybe { short: "c", type: "color", parser: parseColor },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybe : OptionConfigParams data -> CliBuilder (Result data [NoValue]) GetOptionsAction GetOptionsAction
 maybe = \{ parser, type, short ? "", long ? "", help ? "" } ->
@@ -211,14 +207,12 @@ maybe = \{ parser, type, short ? "", long ? "", help ? "" } ->
 ##             other -> Err (InvalidValue "'$(other)' is not a valid color, must be green, red, or blue")
 ##
 ##     { parser } =
-##         Cli.weave {
-##             color: <- Opt.list { short: "c", type: "color", parser: parseColor },
-##         }
+##         Opt.list { short: "c", type: "color", parser: parseColor },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-c", "green", "--color=red"]
-##     == SuccessfullyParsed { answer: [Green, Red] }
+##     == SuccessfullyParsed [Green, Red]
 ## ```
 list : OptionConfigParams data -> CliBuilder (List data) GetOptionsAction GetOptionsAction
 list = \{ parser, type, short ? "", long ? "", help ? "" } ->
@@ -242,14 +236,12 @@ list = \{ parser, type, short ? "", long ? "", help ? "" } ->
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             force: <- Opt.flag { short: "f", long: "force" },
-##         }
+##         Opt.flag { short: "f", long: "force" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-f"]
-##     == SuccessfullyParsed { force: Bool.true }
+##     == SuccessfullyParsed Bool.true
 ## ```
 flag : OptionConfigBaseParams -> CliBuilder Bool GetOptionsAction GetOptionsAction
 flag = \{ short ? "", long ? "", help ? "" } ->
@@ -274,14 +266,12 @@ flag = \{ short ? "", long ? "", help ? "" } ->
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             force: <- Opt.count { short: "f", long: "force" },
-##         }
+##         Opt.count { short: "f", long: "force" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-f", "--force", "-fff"]
-##     == SuccessfullyParsed { force: 5 }
+##     == SuccessfullyParsed 5
 ## ```
 count : OptionConfigBaseParams -> CliBuilder U64 GetOptionsAction GetOptionsAction
 count = \{ short ? "", long ? "", help ? "" } ->
@@ -303,14 +293,12 @@ count = \{ short ? "", long ? "", help ? "" } ->
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.str { long: "answer" },
-##         }
+##         Opt.str { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=abc"]
-##     == SuccessfullyParsed { answer: "abc" }
+##     == SuccessfullyParsed "abc"
 ## ```
 str : OptionConfigBaseParams -> CliBuilder Str GetOptionsAction GetOptionsAction
 str = \{ short ? "", long ? "", help ? "" } -> single { parser: Ok, type: strTypeName, short, long, help }
@@ -323,14 +311,12 @@ str = \{ short ? "", long ? "", help ? "" } -> single { parser: Ok, type: strTyp
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeStr { long: "answer" },
-##         }
+##         Opt.maybeStr { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeStr : OptionConfigBaseParams -> CliBuilder (Result Str [NoValue]) GetOptionsAction GetOptionsAction
 maybeStr = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Ok, type: strTypeName, short, long, help }
@@ -344,14 +330,12 @@ maybeStr = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Ok, type: st
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.strList { long: "answer" },
-##         }
+##         Opt.strList { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "abc", "--answer", "def", "--answer=ghi"]
-##     == SuccessfullyParsed { answer: ["abc", "def", "ghi"] }
+##     == SuccessfullyParsed ["abc", "def", "ghi"]
 ## ```
 strList : OptionConfigBaseParams -> CliBuilder (List Str) GetOptionsAction GetOptionsAction
 strList = \{ short ? "", long ? "", help ? "" } -> list { parser: Ok, type: strTypeName, short, long, help }
@@ -364,14 +348,12 @@ strList = \{ short ? "", long ? "", help ? "" } -> list { parser: Ok, type: strT
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.dec { long: "answer" },
-##         }
+##         Opt.dec { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42.5"]
-##     == SuccessfullyParsed { answer: 42.5 }
+##     == SuccessfullyParsed 42.5
 ## ```
 dec : OptionConfigBaseParams -> CliBuilder Dec GetOptionsAction GetOptionsAction
 dec = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toDec, type: numTypeName, short, long, help }
@@ -384,14 +366,12 @@ dec = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toDec, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeDec { long: "answer" },
-##         }
+##         Opt.maybeDec { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeDec : OptionConfigBaseParams -> CliBuilder (Result Dec [NoValue]) GetOptionsAction GetOptionsAction
 maybeDec = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toDec, type: numTypeName, short, long, help }
@@ -405,14 +385,12 @@ maybeDec = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toDec, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.decList { long: "answer" },
-##         }
+##         Opt.decList { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "-3.0"]
-##     == SuccessfullyParsed { answer: [1.0, 2.0, -3.0] }
+##     == SuccessfullyParsed [1.0, 2.0, -3.0]
 ## ```
 decList : OptionConfigBaseParams -> CliBuilder (List Dec) GetOptionsAction GetOptionsAction
 decList = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toDec, type: numTypeName, short, long, help }
@@ -425,14 +403,12 @@ decList = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toDec, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.f32 { long: "answer" },
-##         }
+##         Opt.f32 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42.5"]
-##     == SuccessfullyParsed { answer: 42.5 }
+##     == SuccessfullyParsed 42.5
 ## ```
 f32 : OptionConfigBaseParams -> CliBuilder F32 GetOptionsAction GetOptionsAction
 f32 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toF32, type: numTypeName, short, long, help }
@@ -445,14 +421,12 @@ f32 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toF32, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeF32 { long: "answer" },
-##         }
+##         Opt.maybeF32 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeF32 : OptionConfigBaseParams -> CliBuilder (Result F32 [NoValue]) GetOptionsAction GetOptionsAction
 maybeF32 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toF32, type: numTypeName, short, long, help }
@@ -466,14 +440,12 @@ maybeF32 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toF32, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.f32List { long: "answer" },
-##         }
+##         Opt.f32List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "-3.0"]
-##     == SuccessfullyParsed { answer: [1.0, 2.0, -3.0] }
+##     == SuccessfullyParsed [1.0, 2.0, -3.0]
 ## ```
 f32List : OptionConfigBaseParams -> CliBuilder (List F32) GetOptionsAction GetOptionsAction
 f32List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toF32, type: numTypeName, short, long, help }
@@ -486,14 +458,12 @@ f32List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toF32, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.f64 { long: "answer" },
-##         }
+##         Opt.f64 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42.5"]
-##     == SuccessfullyParsed { answer: 42.5 }
+##     == SuccessfullyParsed 42.5
 ## ```
 f64 : OptionConfigBaseParams -> CliBuilder F64 GetOptionsAction GetOptionsAction
 f64 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toF64, type: numTypeName, short, long, help }
@@ -506,14 +476,12 @@ f64 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toF64, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeF64 { long: "answer" },
-##         }
+##         Opt.maybeF64 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeF64 : OptionConfigBaseParams -> CliBuilder (Result F64 [NoValue]) GetOptionsAction GetOptionsAction
 maybeF64 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toF64, type: numTypeName, short, long, help }
@@ -527,14 +495,12 @@ maybeF64 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toF64, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.f64List { long: "answer" },
-##         }
+##         Opt.f64List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "-3.0"]
-##     == SuccessfullyParsed { answer: [1.0, 2.0, -3.0] }
+##     == SuccessfullyParsed [1.0, 2.0, -3.0]
 ## ```
 f64List : OptionConfigBaseParams -> CliBuilder (List F64) GetOptionsAction GetOptionsAction
 f64List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toF64, type: numTypeName, short, long, help }
@@ -547,14 +513,12 @@ f64List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toF64, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u8 { long: "answer" },
-##         }
+##         Opt.u8 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u8 : OptionConfigBaseParams -> CliBuilder U8 GetOptionsAction GetOptionsAction
 u8 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU8, type: numTypeName, short, long, help }
@@ -567,14 +531,12 @@ u8 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU8, type: n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeU8 { long: "answer" },
-##         }
+##         Opt.maybeU8 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU8 : OptionConfigBaseParams -> CliBuilder (Result U8 [NoValue]) GetOptionsAction GetOptionsAction
 maybeU8 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU8, type: numTypeName, short, long, help }
@@ -588,14 +550,12 @@ maybeU8 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU8, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u8List { long: "answer" },
-##         }
+##         Opt.u8List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 u8List : OptionConfigBaseParams -> CliBuilder (List U8) GetOptionsAction GetOptionsAction
 u8List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU8, type: numTypeName, short, long, help }
@@ -608,14 +568,12 @@ u8List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU8, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u16 { long: "answer" },
-##         }
+##         Opt.u16 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u16 : OptionConfigBaseParams -> CliBuilder U16 GetOptionsAction GetOptionsAction
 u16 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU16, type: numTypeName, short, long, help }
@@ -628,14 +586,12 @@ u16 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU16, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeU16 { long: "answer" },
-##         }
+##         Opt.maybeU16 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU16 : OptionConfigBaseParams -> CliBuilder (Result U16 [NoValue]) GetOptionsAction GetOptionsAction
 maybeU16 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU16, type: numTypeName, short, long, help }
@@ -649,14 +605,12 @@ maybeU16 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU16, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u16List { long: "answer" },
-##         }
+##         Opt.u16List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 u16List : OptionConfigBaseParams -> CliBuilder (List U16) GetOptionsAction GetOptionsAction
 u16List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU16, type: numTypeName, short, long, help }
@@ -669,14 +623,12 @@ u16List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU16, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u32 { long: "answer" },
-##         }
+##         Opt.u32 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u32 : OptionConfigBaseParams -> CliBuilder U32 GetOptionsAction GetOptionsAction
 u32 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU32, type: numTypeName, short, long, help }
@@ -689,14 +641,12 @@ u32 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU32, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeU32 { long: "answer" },
-##         }
+##         Opt.maybeU32 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU32 : OptionConfigBaseParams -> CliBuilder (Result U32 [NoValue]) GetOptionsAction GetOptionsAction
 maybeU32 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU32, type: numTypeName, short, long, help }
@@ -710,14 +660,12 @@ maybeU32 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU32, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u32List { long: "answer" },
-##         }
+##         Opt.u32List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 u32List : OptionConfigBaseParams -> CliBuilder (List U32) GetOptionsAction GetOptionsAction
 u32List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU32, type: numTypeName, short, long, help }
@@ -730,14 +678,12 @@ u32List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU32, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u64 { long: "answer" },
-##         }
+##         Opt.u64 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u64 : OptionConfigBaseParams -> CliBuilder U64 GetOptionsAction GetOptionsAction
 u64 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU64, type: numTypeName, short, long, help }
@@ -750,14 +696,12 @@ u64 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU64, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeU64 { long: "answer" },
-##         }
+##         Opt.maybeU64 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU64 : OptionConfigBaseParams -> CliBuilder (Result U64 [NoValue]) GetOptionsAction GetOptionsAction
 maybeU64 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU64, type: numTypeName, short, long, help }
@@ -771,14 +715,12 @@ maybeU64 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU64, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u64List { long: "answer" },
-##         }
+##         Opt.u64List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 u64List : OptionConfigBaseParams -> CliBuilder (List U64) GetOptionsAction GetOptionsAction
 u64List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU64, type: numTypeName, short, long, help }
@@ -791,14 +733,12 @@ u64List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU64, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u128 { long: "answer" },
-##         }
+##         Opt.u128 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u128 : OptionConfigBaseParams -> CliBuilder U128 GetOptionsAction GetOptionsAction
 u128 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU128, type: numTypeName, short, long, help }
@@ -811,14 +751,12 @@ u128 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toU128, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeU128 { long: "answer" },
-##         }
+##         Opt.maybeU128 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU128 : OptionConfigBaseParams -> CliBuilder (Result U128 [NoValue]) GetOptionsAction GetOptionsAction
 maybeU128 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU128, type: numTypeName, short, long, help }
@@ -832,14 +770,12 @@ maybeU128 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toU128,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.u128List { long: "answer" },
-##         }
+##         Opt.u128List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 u128List : OptionConfigBaseParams -> CliBuilder (List U128) GetOptionsAction GetOptionsAction
 u128List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU128, type: numTypeName, short, long, help }
@@ -852,14 +788,12 @@ u128List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toU128, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i8 { long: "answer" },
-##         }
+##         Opt.i8 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i8 : OptionConfigBaseParams -> CliBuilder I8 GetOptionsAction GetOptionsAction
 i8 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI8, type: numTypeName, short, long, help }
@@ -872,14 +806,12 @@ i8 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI8, type: n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeI8 { long: "answer" },
-##         }
+##         Opt.maybeI8 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI8 : OptionConfigBaseParams -> CliBuilder (Result I8 [NoValue]) GetOptionsAction GetOptionsAction
 maybeI8 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI8, type: numTypeName, short, long, help }
@@ -893,14 +825,12 @@ maybeI8 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI8, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i8List { long: "answer" },
-##         }
+##         Opt.i8List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 i8List : OptionConfigBaseParams -> CliBuilder (List I8) GetOptionsAction GetOptionsAction
 i8List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI8, type: numTypeName, short, long, help }
@@ -913,14 +843,12 @@ i8List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI8, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i16 { long: "answer" },
-##         }
+##         Opt.i16 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i16 : OptionConfigBaseParams -> CliBuilder I16 GetOptionsAction GetOptionsAction
 i16 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI16, type: numTypeName, short, long, help }
@@ -933,14 +861,12 @@ i16 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI16, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeI16 { long: "answer" },
-##         }
+##         Opt.maybeI16 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI16 : OptionConfigBaseParams -> CliBuilder (Result I16 [NoValue]) GetOptionsAction GetOptionsAction
 maybeI16 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI16, type: numTypeName, short, long, help }
@@ -954,14 +880,12 @@ maybeI16 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI16, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i16List { long: "answer" },
-##         }
+##         Opt.i16List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 i16List : OptionConfigBaseParams -> CliBuilder (List I16) GetOptionsAction GetOptionsAction
 i16List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI16, type: numTypeName, short, long, help }
@@ -974,14 +898,12 @@ i16List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI16, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i32 { long: "answer" },
-##         }
+##         Opt.i32 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i32 : OptionConfigBaseParams -> CliBuilder I32 GetOptionsAction GetOptionsAction
 i32 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI32, type: numTypeName, short, long, help }
@@ -994,14 +916,12 @@ i32 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI32, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeI32 { long: "answer" },
-##         }
+##         Opt.maybeI32 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI32 : OptionConfigBaseParams -> CliBuilder (Result I32 [NoValue]) GetOptionsAction GetOptionsAction
 maybeI32 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI32, type: numTypeName, short, long, help }
@@ -1015,14 +935,12 @@ maybeI32 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI32, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i32List { long: "answer" },
-##         }
+##         Opt.i32List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 i32List : OptionConfigBaseParams -> CliBuilder (List I32) GetOptionsAction GetOptionsAction
 i32List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI32, type: numTypeName, short, long, help }
@@ -1035,14 +953,12 @@ i32List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI32, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i64 { long: "answer" },
-##         }
+##         Opt.i64 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i64 : OptionConfigBaseParams -> CliBuilder I64 GetOptionsAction GetOptionsAction
 i64 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI64, type: numTypeName, short, long, help }
@@ -1055,14 +971,12 @@ i64 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI64, type:
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeI64 { long: "answer" },
-##         }
+##         Opt.maybeI64 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI64 : OptionConfigBaseParams -> CliBuilder (Result I64 [NoValue]) GetOptionsAction GetOptionsAction
 maybeI64 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI64, type: numTypeName, short, long, help }
@@ -1076,14 +990,12 @@ maybeI64 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI64, t
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i64List { long: "answer" },
-##         }
+##         Opt.i64List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 i64List : OptionConfigBaseParams -> CliBuilder (List I64) GetOptionsAction GetOptionsAction
 i64List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI64, type: numTypeName, short, long, help }
@@ -1096,14 +1008,12 @@ i64List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI64, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i128 { long: "answer" },
-##         }
+##         Opt.i128 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "--answer=42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i128 : OptionConfigBaseParams -> CliBuilder I128 GetOptionsAction GetOptionsAction
 i128 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI128, type: numTypeName, short, long, help }
@@ -1116,14 +1026,12 @@ i128 = \{ short ? "", long ? "", help ? "" } -> single { parser: Str.toI128, typ
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.maybeI128 { long: "answer" },
-##         }
+##         Opt.maybeI128 { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI128 : OptionConfigBaseParams -> CliBuilder (Result I128 [NoValue]) GetOptionsAction GetOptionsAction
 maybeI128 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI128, type: numTypeName, short, long, help }
@@ -1137,14 +1045,12 @@ maybeI128 = \{ short ? "", long ? "", help ? "" } -> maybe { parser: Str.toI128,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Opt.i128List { long: "answer" },
-##         }
+##         Opt.i128List { long: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "-a", "1", "--answer=2", "--answer", "3"]
-##     == SuccessfullyParsed { answer: [1, 2, 3] }
+##     == SuccessfullyParsed [1, 2, 3]
 ## ```
 i128List : OptionConfigBaseParams -> CliBuilder (List I128) GetOptionsAction GetOptionsAction
 i128List = \{ short ? "", long ? "", help ? "" } -> list { parser: Str.toI128, type: numTypeName, short, long, help }

--- a/package/Param.roc
+++ b/package/Param.roc
@@ -105,14 +105,12 @@ builderWithParameterParser = \param, valueParser ->
 ##             other -> Err (InvalidValue "'$(other)' is not a valid color, must be green, red, or blue")
 ##
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.single { name: "answer", type: "color", parser: parseColor },
-##         }
+##         Param.single { name: "answer", type: "color", parser: parseColor },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "blue"]
-##     == SuccessfullyParsed { answer: Blue }
+##     == SuccessfullyParsed Blue
 ## ```
 single : ParameterConfigParams state -> CliBuilder state {}action GetParamsAction
 single = \{ parser, type, name, help ? "" } ->
@@ -156,14 +154,12 @@ single = \{ parser, type, name, help ? "" } ->
 ##             other -> Err (InvalidValue "'$(other)' is not a valid color, must be green, red, or blue")
 ##
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybe { name: "answer", type: "color", parser: parseColor },
-##         }
+##         Param.maybe { name: "answer", type: "color", parser: parseColor },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybe : ParameterConfigParams data -> CliBuilder (Result data [NoValue]) {}action GetParamsAction
 maybe = \{ parser, type, name, help ? "" } ->
@@ -209,14 +205,12 @@ maybe = \{ parser, type, name, help ? "" } ->
 ##             other -> Err (InvalidValue "'$(other)' is not a valid color, must be green, red, or blue")
 ##
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.list { name: "answer", type: "color", parser: parseColor },
-##         }
+##         Param.list { name: "answer", type: "color", parser: parseColor },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "blue", "red", "green"]
-##     == SuccessfullyParsed { answer: [Blue, Red, Green] }
+##     == SuccessfullyParsed [Blue, Red, Green]
 ## ```
 list : ParameterConfigParams data -> CliBuilder (List data) {}action StopCollectingAction
 list = \{ parser, type, name, help ? "" } ->
@@ -235,14 +229,12 @@ list = \{ parser, type, name, help ? "" } ->
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.str { name: "answer" },
-##         }
+##         Param.str { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "abc"]
-##     == SuccessfullyParsed { answer: "abc" }
+##     == SuccessfullyParsed "abc"
 ## ```
 str : ParameterConfigBaseParams -> CliBuilder Str {}action GetParamsAction
 str = \{ name, help ? "" } -> single { parser: Ok, type: strTypeName, name, help }
@@ -254,14 +246,12 @@ str = \{ name, help ? "" } -> single { parser: Ok, type: strTypeName, name, help
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeStr { name: "answer" },
-##         }
+##         Param.maybeStr { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeStr : ParameterConfigBaseParams -> CliBuilder ArgValue {}action GetParamsAction
 maybeStr = \{ name, help ? "" } -> maybe { parser: Ok, type: strTypeName, name, help }
@@ -274,14 +264,12 @@ maybeStr = \{ name, help ? "" } -> maybe { parser: Ok, type: strTypeName, name, 
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.strList { name: "answer" },
-##         }
+##         Param.strList { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "abc", "def", "ghi"]
-##     == SuccessfullyParsed { answer: ["abc", "def", "ghi"] }
+##     == SuccessfullyParsed ["abc", "def", "ghi"]
 ## ```
 strList : ParameterConfigBaseParams -> CliBuilder (List Str) {}action StopCollectingAction
 strList = \{ name, help ? "" } -> list { parser: Ok, type: strTypeName, name, help }
@@ -294,14 +282,12 @@ strList = \{ name, help ? "" } -> list { parser: Ok, type: strTypeName, name, he
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.dec { name: "answer" },
-##         }
+##         Param.dec { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42.5"]
-##     == SuccessfullyParsed { answer: 42.5 }
+##     == SuccessfullyParsed 42.5
 ## ```
 dec : ParameterConfigBaseParams -> CliBuilder Dec {}action GetParamsAction
 dec = \{ name, help ? "" } -> single { parser: Str.toDec, type: numTypeName, name, help }
@@ -313,14 +299,12 @@ dec = \{ name, help ? "" } -> single { parser: Str.toDec, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeDec { name: "answer" },
-##         }
+##         Param.maybeDec { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeDec : ParameterConfigBaseParams -> CliBuilder (Result Dec [NoValue]) {}action GetParamsAction
 maybeDec = \{ name, help ? "" } -> maybe { parser: Str.toDec, type: numTypeName, name, help }
@@ -334,14 +318,12 @@ maybeDec = \{ name, help ? "" } -> maybe { parser: Str.toDec, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.decList { name: "answer" },
-##         }
+##         Param.decList { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56.0"]
-##     == SuccessfullyParsed { answer: [12.0, 34.0, -56.0] }
+##     == SuccessfullyParsed [12.0, 34.0, -56.0]
 ## ```
 decList : ParameterConfigBaseParams -> CliBuilder (List Dec) {}action StopCollectingAction
 decList = \{ name, help ? "" } -> list { parser: Str.toDec, type: numTypeName, name, help }
@@ -354,14 +336,12 @@ decList = \{ name, help ? "" } -> list { parser: Str.toDec, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.f32 { name: "answer" },
-##         }
+##         Param.f32 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42.5"]
-##     == SuccessfullyParsed { answer: 42.5 }
+##     == SuccessfullyParsed 42.5
 ## ```
 f32 : ParameterConfigBaseParams -> CliBuilder F32 {}action GetParamsAction
 f32 = \{ name, help ? "" } -> single { parser: Str.toF32, type: numTypeName, name, help }
@@ -373,14 +353,12 @@ f32 = \{ name, help ? "" } -> single { parser: Str.toF32, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeF32 { name: "answer" },
-##         }
+##         Param.maybeF32 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeF32 : ParameterConfigBaseParams -> CliBuilder (Result F32 [NoValue]) {}action GetParamsAction
 maybeF32 = \{ name, help ? "" } -> maybe { parser: Str.toF32, type: numTypeName, name, help }
@@ -394,14 +372,12 @@ maybeF32 = \{ name, help ? "" } -> maybe { parser: Str.toF32, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.f32List { name: "answer" },
-##         }
+##         Param.f32List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56.0"]
-##     == SuccessfullyParsed { answer: [12.0, 34.0, -56.0] }
+##     == SuccessfullyParsed [12.0, 34.0, -56.0]
 ## ```
 f32List : ParameterConfigBaseParams -> CliBuilder (List F32) {}action StopCollectingAction
 f32List = \{ name, help ? "" } -> list { parser: Str.toF32, type: numTypeName, name, help }
@@ -414,14 +390,12 @@ f32List = \{ name, help ? "" } -> list { parser: Str.toF32, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.f64 { name: "answer" },
-##         }
+##         Param.f64 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42.5"]
-##     == SuccessfullyParsed { answer: 42.5 }
+##     == SuccessfullyParsed 42.5
 ## ```
 f64 : ParameterConfigBaseParams -> CliBuilder F64 {}action GetParamsAction
 f64 = \{ name, help ? "" } -> single { parser: Str.toF64, type: numTypeName, name, help }
@@ -433,14 +407,12 @@ f64 = \{ name, help ? "" } -> single { parser: Str.toF64, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeF64 { name: "answer" },
-##         }
+##         Param.maybeF64 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeF64 : ParameterConfigBaseParams -> CliBuilder (Result F64 [NoValue]) {}action GetParamsAction
 maybeF64 = \{ name, help ? "" } -> maybe { parser: Str.toF64, type: numTypeName, name, help }
@@ -454,14 +426,12 @@ maybeF64 = \{ name, help ? "" } -> maybe { parser: Str.toF64, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.f64List { name: "answer" },
-##         }
+##         Param.f64List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56.0"]
-##     == SuccessfullyParsed { answer: [12, 34, -56.0] }
+##     == SuccessfullyParsed [12, 34, -56.0]
 ## ```
 f64List : ParameterConfigBaseParams -> CliBuilder (List F64) {}action StopCollectingAction
 f64List = \{ name, help ? "" } -> list { parser: Str.toF64, type: numTypeName, name, help }
@@ -474,14 +444,12 @@ f64List = \{ name, help ? "" } -> list { parser: Str.toF64, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u8 { name: "answer" },
-##         }
+##         Param.u8 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u8 : ParameterConfigBaseParams -> CliBuilder U8 {}action GetParamsAction
 u8 = \{ name, help ? "" } -> single { parser: Str.toU8, type: numTypeName, name, help }
@@ -493,14 +461,12 @@ u8 = \{ name, help ? "" } -> single { parser: Str.toU8, type: numTypeName, name,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeU8 { name: "answer" },
-##         }
+##         Param.maybeU8 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU8 : ParameterConfigBaseParams -> CliBuilder (Result U8 [NoValue]) {}action GetParamsAction
 maybeU8 = \{ name, help ? "" } -> maybe { parser: Str.toU8, type: numTypeName, name, help }
@@ -514,14 +480,12 @@ maybeU8 = \{ name, help ? "" } -> maybe { parser: Str.toU8, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u8List { name: "answer" },
-##         }
+##         Param.u8List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "56"]
-##     == SuccessfullyParsed { answer: [12, 34, 56] }
+##     == SuccessfullyParsed [12, 34, 56]
 ## ```
 u8List : ParameterConfigBaseParams -> CliBuilder (List U8) {}action StopCollectingAction
 u8List = \{ name, help ? "" } -> list { parser: Str.toU8, type: numTypeName, name, help }
@@ -534,14 +498,12 @@ u8List = \{ name, help ? "" } -> list { parser: Str.toU8, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u16 { name: "answer" },
-##         }
+##         Param.u16 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u16 : ParameterConfigBaseParams -> CliBuilder U16 {}action GetParamsAction
 u16 = \{ name, help ? "" } -> single { parser: Str.toU16, type: numTypeName, name, help }
@@ -553,14 +515,12 @@ u16 = \{ name, help ? "" } -> single { parser: Str.toU16, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeU16 { name: "answer" },
-##         }
+##         Param.maybeU16 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU16 : ParameterConfigBaseParams -> CliBuilder (Result U16 [NoValue]) {}action GetParamsAction
 maybeU16 = \{ name, help ? "" } -> maybe { parser: Str.toU16, type: numTypeName, name, help }
@@ -574,14 +534,12 @@ maybeU16 = \{ name, help ? "" } -> maybe { parser: Str.toU16, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u16List { name: "answer" },
-##         }
+##         Param.u16List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "56"]
-##     == SuccessfullyParsed { answer: [12, 34, 56] }
+##     == SuccessfullyParsed [12, 34, 56]
 ## ```
 u16List : ParameterConfigBaseParams -> CliBuilder (List U16) {}action StopCollectingAction
 u16List = \{ name, help ? "" } -> list { parser: Str.toU16, type: numTypeName, name, help }
@@ -594,14 +552,12 @@ u16List = \{ name, help ? "" } -> list { parser: Str.toU16, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u32 { name: "answer" },
-##         }
+##         Param.u32 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u32 : ParameterConfigBaseParams -> CliBuilder U32 {}action GetParamsAction
 u32 = \{ name, help ? "" } -> single { parser: Str.toU32, type: numTypeName, name, help }
@@ -613,14 +569,12 @@ u32 = \{ name, help ? "" } -> single { parser: Str.toU32, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeU32 { name: "answer" },
-##         }
+##         Param.maybeU32 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU32 : ParameterConfigBaseParams -> CliBuilder (Result U32 [NoValue]) {}action GetParamsAction
 maybeU32 = \{ name, help ? "" } -> maybe { parser: Str.toU32, type: numTypeName, name, help }
@@ -634,14 +588,12 @@ maybeU32 = \{ name, help ? "" } -> maybe { parser: Str.toU32, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u32List { name: "answer" },
-##         }
+##         Param.u32List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "56"]
-##     == SuccessfullyParsed { answer: [12, 34, 56] }
+##     == SuccessfullyParsed [12, 34, 56]
 ## ```
 u32List : ParameterConfigBaseParams -> CliBuilder (List U32) {}action StopCollectingAction
 u32List = \{ name, help ? "" } -> list { parser: Str.toU32, type: numTypeName, name, help }
@@ -654,14 +606,12 @@ u32List = \{ name, help ? "" } -> list { parser: Str.toU32, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u64 { name: "answer" },
-##         }
+##         Param.u64 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u64 : ParameterConfigBaseParams -> CliBuilder U64 {}action GetParamsAction
 u64 = \{ name, help ? "" } -> single { parser: Str.toU64, type: numTypeName, name, help }
@@ -673,14 +623,12 @@ u64 = \{ name, help ? "" } -> single { parser: Str.toU64, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeU64 { name: "answer" },
-##         }
+##         Param.maybeU64 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU64 : ParameterConfigBaseParams -> CliBuilder (Result U64 [NoValue]) {}action GetParamsAction
 maybeU64 = \{ name, help ? "" } -> maybe { parser: Str.toU64, type: numTypeName, name, help }
@@ -694,14 +642,12 @@ maybeU64 = \{ name, help ? "" } -> maybe { parser: Str.toU64, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u64List { name: "answer" },
-##         }
+##         Param.u64List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "56"]
-##     == SuccessfullyParsed { answer: [12, 34, 56] }
+##     == SuccessfullyParsed [12, 34, 56]
 ## ```
 u64List : ParameterConfigBaseParams -> CliBuilder (List U64) {}action StopCollectingAction
 u64List = \{ name, help ? "" } -> list { parser: Str.toU64, type: numTypeName, name, help }
@@ -714,14 +660,12 @@ u64List = \{ name, help ? "" } -> list { parser: Str.toU64, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u128 { name: "answer" },
-##         }
+##         Param.u128 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 u128 : ParameterConfigBaseParams -> CliBuilder U128 {}action GetParamsAction
 u128 = \{ name, help ? "" } -> single { parser: Str.toU128, type: numTypeName, name, help }
@@ -733,14 +677,12 @@ u128 = \{ name, help ? "" } -> single { parser: Str.toU128, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeU128 { name: "answer" },
-##         }
+##         Param.maybeU128 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeU128 : ParameterConfigBaseParams -> CliBuilder (Result U128 [NoValue]) {}action GetParamsAction
 maybeU128 = \{ name, help ? "" } -> maybe { parser: Str.toU128, type: numTypeName, name, help }
@@ -754,14 +696,12 @@ maybeU128 = \{ name, help ? "" } -> maybe { parser: Str.toU128, type: numTypeNam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.u128List { name: "answer" },
-##         }
+##         Param.u128List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "56"]
-##     == SuccessfullyParsed { answer: [12, 34, 56] }
+##     == SuccessfullyParsed [12, 34, 56]
 ## ```
 u128List : ParameterConfigBaseParams -> CliBuilder (List U128) {}action StopCollectingAction
 u128List = \{ name, help ? "" } -> list { parser: Str.toU128, type: numTypeName, name, help }
@@ -774,14 +714,12 @@ u128List = \{ name, help ? "" } -> list { parser: Str.toU128, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i8 { name: "answer" },
-##         }
+##         Param.i8 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i8 : ParameterConfigBaseParams -> CliBuilder I8 {}action GetParamsAction
 i8 = \{ name, help ? "" } -> single { parser: Str.toI8, type: numTypeName, name, help }
@@ -793,14 +731,12 @@ i8 = \{ name, help ? "" } -> single { parser: Str.toI8, type: numTypeName, name,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeI8 { name: "answer" },
-##         }
+##         Param.maybeI8 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI8 : ParameterConfigBaseParams -> CliBuilder (Result I8 [NoValue]) {}action GetParamsAction
 maybeI8 = \{ name, help ? "" } -> maybe { parser: Str.toI8, type: numTypeName, name, help }
@@ -814,14 +750,12 @@ maybeI8 = \{ name, help ? "" } -> maybe { parser: Str.toI8, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i8List { name: "answer" },
-##         }
+##         Param.i8List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56"]
-##     == SuccessfullyParsed { answer: [12, 34, -56] }
+##     == SuccessfullyParsed [12, 34, -56]
 ## ```
 i8List : ParameterConfigBaseParams -> CliBuilder (List I8) {}action StopCollectingAction
 i8List = \{ name, help ? "" } -> list { parser: Str.toI8, type: numTypeName, name, help }
@@ -834,14 +768,12 @@ i8List = \{ name, help ? "" } -> list { parser: Str.toI8, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i16 { name: "answer" },
-##         }
+##         Param.i16 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i16 : ParameterConfigBaseParams -> CliBuilder I16 {}action GetParamsAction
 i16 = \{ name, help ? "" } -> single { parser: Str.toI16, type: numTypeName, name, help }
@@ -853,14 +785,12 @@ i16 = \{ name, help ? "" } -> single { parser: Str.toI16, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeI16 { name: "answer" },
-##         }
+##         Param.maybeI16 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI16 : ParameterConfigBaseParams -> CliBuilder (Result I16 [NoValue]) {}action GetParamsAction
 maybeI16 = \{ name, help ? "" } -> maybe { parser: Str.toI16, type: numTypeName, name, help }
@@ -874,14 +804,12 @@ maybeI16 = \{ name, help ? "" } -> maybe { parser: Str.toI16, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i16List { name: "answer" },
-##         }
+##         Param.i16List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56"]
-##     == SuccessfullyParsed { answer: [12, 34, -56] }
+##     == SuccessfullyParsed [12, 34, -56]
 ## ```
 i16List : ParameterConfigBaseParams -> CliBuilder (List I16) {}action StopCollectingAction
 i16List = \{ name, help ? "" } -> list { parser: Str.toI16, type: numTypeName, name, help }
@@ -894,14 +822,12 @@ i16List = \{ name, help ? "" } -> list { parser: Str.toI16, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i32 { name: "answer" },
-##         }
+##         Param.i32 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i32 : ParameterConfigBaseParams -> CliBuilder I32 {}action GetParamsAction
 i32 = \{ name, help ? "" } -> single { parser: Str.toI32, type: numTypeName, name, help }
@@ -913,14 +839,12 @@ i32 = \{ name, help ? "" } -> single { parser: Str.toI32, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeI32 { name: "answer" },
-##         }
+##         Param.maybeI32 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI32 : ParameterConfigBaseParams -> CliBuilder (Result I32 [NoValue]) {}action GetParamsAction
 maybeI32 = \{ name, help ? "" } -> maybe { parser: Str.toI32, type: numTypeName, name, help }
@@ -934,14 +858,12 @@ maybeI32 = \{ name, help ? "" } -> maybe { parser: Str.toI32, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i32List { name: "answer" },
-##         }
+##         Param.i32List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56"]
-##     == SuccessfullyParsed { answer: [12, 34, -56] }
+##     == SuccessfullyParsed [12, 34, -56]
 ## ```
 i32List : ParameterConfigBaseParams -> CliBuilder (List I32) {}action StopCollectingAction
 i32List = \{ name, help ? "" } -> list { parser: Str.toI32, type: numTypeName, name, help }
@@ -954,14 +876,12 @@ i32List = \{ name, help ? "" } -> list { parser: Str.toI32, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i64 { name: "answer" },
-##         }
+##         Param.i64 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i64 : ParameterConfigBaseParams -> CliBuilder I64 {}action GetParamsAction
 i64 = \{ name, help ? "" } -> single { parser: Str.toI64, type: numTypeName, name, help }
@@ -973,14 +893,12 @@ i64 = \{ name, help ? "" } -> single { parser: Str.toI64, type: numTypeName, nam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeI64 { name: "answer" },
-##         }
+##         Param.maybeI64 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI64 : ParameterConfigBaseParams -> CliBuilder (Result I64 [NoValue]) {}action GetParamsAction
 maybeI64 = \{ name, help ? "" } -> maybe { parser: Str.toI64, type: numTypeName, name, help }
@@ -994,14 +912,12 @@ maybeI64 = \{ name, help ? "" } -> maybe { parser: Str.toI64, type: numTypeName,
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i64List { name: "answer" },
-##         }
+##         Param.i64List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56"]
-##     == SuccessfullyParsed { answer: [12, 34, -56] }
+##     == SuccessfullyParsed [12, 34, -56]
 ## ```
 i64List : ParameterConfigBaseParams -> CliBuilder (List I64) {}action StopCollectingAction
 i64List = \{ name, help ? "" } -> list { parser: Str.toI64, type: numTypeName, name, help }
@@ -1014,14 +930,12 @@ i64List = \{ name, help ? "" } -> list { parser: Str.toI64, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i128 { name: "answer" },
-##         }
+##         Param.i128 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "42"]
-##     == SuccessfullyParsed { answer: 42 }
+##     == SuccessfullyParsed 42
 ## ```
 i128 : ParameterConfigBaseParams -> CliBuilder I128 {}action GetParamsAction
 i128 = \{ name, help ? "" } -> single { parser: Str.toI128, type: numTypeName, name, help }
@@ -1033,14 +947,12 @@ i128 = \{ name, help ? "" } -> single { parser: Str.toI128, type: numTypeName, n
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.maybeI128 { name: "answer" },
-##         }
+##         Param.maybeI128 { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example"]
-##     == SuccessfullyParsed { answer: Err NoValue }
+##     == SuccessfullyParsed (Err NoValue)
 ## ```
 maybeI128 : ParameterConfigBaseParams -> CliBuilder (Result I128 [NoValue]) {}action GetParamsAction
 maybeI128 = \{ name, help ? "" } -> maybe { parser: Str.toI128, type: numTypeName, name, help }
@@ -1054,14 +966,12 @@ maybeI128 = \{ name, help ? "" } -> maybe { parser: Str.toI128, type: numTypeNam
 ## ```roc
 ## expect
 ##     { parser } =
-##         Cli.weave {
-##             answer: <- Param.i128List { name: "answer" },
-##         }
+##         Param.i128List { name: "answer" },
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
 ##     parser ["example", "12", "34", "--", "-56"]
-##     == SuccessfullyParsed { answer: [12, 34, -56] }
+##     == SuccessfullyParsed [12, 34, -56]
 ## ```
 i128List : ParameterConfigBaseParams -> CliBuilder (List I128) {}action StopCollectingAction
 i128List = \{ name, help ? "" } -> list { parser: Str.toI128, type: numTypeName, name, help }

--- a/package/Subcommand.roc
+++ b/package/Subcommand.roc
@@ -32,10 +32,11 @@ SubcommandParserConfig subState : {
 ##
 ## ```roc
 ## fooSubcommand =
-##     Cli.weave {
-##         foo: <- Opt.str { short: "f" },
+##     { Cli.weave <-
+##         foo: Opt.str { short: "f" },
+##         bar: Opt.str { short: "b" },
 ##     }
-##     |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
+##     |> Subcommand.finish { name: "foobar", description: "Foo and bar subcommand", mapper: FooBar }
 ## ```
 finish : CliBuilder state fromAction toAction, { name : Str, description ? Str, mapper : state -> commonState } -> { name : Str, parser : ArgParser commonState, config : SubcommandConfig }
 finish = \builder, { name, description ? "", mapper } ->
@@ -93,24 +94,20 @@ getFirstArgToCheckForSubcommandCall = \{ remainingArgs, subcommandPath }, subcom
 ## ```roc
 ## expect
 ##     fooSubcommand =
-##         Cli.weave {
-##             foo: <- Opt.str { short: "f" },
-##         }
+##         Opt.str { short: "f" }
 ##         |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
 ##
 ##     barSubcommand =
-##         Cli.weave {
-##             bar: <- Opt.str { short: "b" },
-##         }
+##         Opt.str { short: "b" }
 ##         |> Subcommand.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
 ##
-##     Cli.weave {
-##         sc: <- Subcommand.optional [fooSubcommand, barSubcommand],
-##     }
-##     |> Cli.finish { name: "example" }
-##     |> Cli.assertValid
-##     |> Cli.parseOrDisplayMessage ["example", "bar", "-b", "abc"]
-##     == Ok { sc: Ok (Bar { b: "abc" }) }
+##     { parser } =
+##         Subcommand.optional [fooSubcommand, barSubcommand],
+##         |> Cli.finish { name: "example" }
+##         |> Cli.assertValid
+##
+##     parser ["example", "bar", "-b", "abc"]
+##     == SuccessfullyParsed (Ok (Bar "abc"))
 ## ```
 optional : List (SubcommandParserConfig subState) -> CliBuilder (Result subState [NoSubcommand]) GetOptionsAction GetParamsAction
 optional = \subcommandConfigs ->
@@ -156,24 +153,20 @@ optional = \subcommandConfigs ->
 ## ```roc
 ## expect
 ##     fooSubcommand =
-##         Cli.weave {
-##             foo: <- Opt.str { short: "f" },
-##         }
+##         Opt.str { short: "f" }
 ##         |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
 ##
 ##     barSubcommand =
-##         Cli.weave {
-##             bar: <- Opt.str { short: "b" },
-##         }
+##         Opt.str { short: "b" }
 ##         |> Subcommand.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
 ##
-##     Cli.weave {
-##         sc: <- Subcommand.required [fooSubcommand, barSubcommand],
-##     }
-##     |> Cli.finish { name: "example" }
-##     |> Cli.assertValid
-##     |> Cli.parseOrDisplayMessage ["example", "bar", "-b", "abc"]
-##     == Ok { sc: Bar { b: "abc" } }
+##     { parser } =
+##         Subcommand.required [fooSubcommand, barSubcommand],
+##         |> Cli.finish { name: "example" }
+##         |> Cli.assertValid
+##
+##     parser ["example", "bar", "-b", "abc"]
+##     == SuccessfullyParsed (Bar "abc")
 ## ```
 required : List (SubcommandParserConfig subData) -> CliBuilder subData GetOptionsAction GetParamsAction
 required = \subcommandConfigs ->


### PR DESCRIPTION
This PR moves Weaver to use the new map2-based record builder syntax over the old applicative one. Once the [language change PR](https://github.com/roc-lang/roc/pull/6883) is merged, we can merge this PR and release v0.3.0 of Weaver. We can then make a PR to update the cloned arg parsing code in the [basic-cli](https://github.com/roc-lang/basic-cli) platform.

I tested this change by successfully running all 3 examples using the code in the above PR. The functionality seems to be identical, but I'll be on the lookout for bugs. 

The last thing to be done in this PR is updating documentation to match the new syntax.