### PR TITLE
Support default values for args

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,4 +33,4 @@ jobs:
       - run: ./roc_nightly/roc version
 
       # run all tests 
-      - run: for f in **/*.roc; do ./roc_nightly/roc test $f; done
+      - run: ./roc_nightly/roc test package/main.roc

--- a/examples/default-values.roc
+++ b/examples/default-values.roc
@@ -26,9 +26,22 @@ main =
 
 cliParser =
     { Cli.weave <-
-        alpha: Opt.maybeU64 { short: "a", long: "alpha", help: "Set the alpha level. [default: 123]" }
-        |> Cli.map \a -> Result.withDefault a 123,,
-        file: Param.maybeStr { name: "file", help: "The file to process. [default: NONE]" }
+        alpha: Opt.u64 {
+            short: "a",
+            long: "alpha",
+            help: "Set the alpha level. [default: 123]",
+            default: Value 123,
+        },
+        beta: Opt.dec {
+            short: "b",
+            long: "beta",
+            help: "Set the beta level. [default: PI]",
+            default: Generate (\{} -> Num.pi),
+        },
+        file: Param.maybeStr {
+            name: "file",
+            help: "The file to process. [default: NONE]",
+        }
         |> Cli.map \f -> Result.withDefault f "NONE",
     }
     |> Cli.finish {

--- a/examples/subcommands.roc
+++ b/examples/subcommands.roc
@@ -9,7 +9,7 @@ import pf.Task exposing [Task]
 import weaver.Opt
 import weaver.Cli
 import weaver.Param
-import weaver.Subcommand
+import weaver.SubCmd
 
 main =
     args = Arg.list!
@@ -28,7 +28,7 @@ main =
 cliParser =
     { Cli.weave <-
         force: Opt.flag { short: "f", help: "Force the task to complete." },
-        sc: Subcommand.optional [subcommandParser1, subcommandParser2],
+        sc: SubCmd.optional [subcommandParser1, subcommandParser2],
         file: Param.maybeStr { name: "file", help: "The file to process." },
         files: Param.strList { name: "files", help: "The rest of the files." },
     }
@@ -44,14 +44,14 @@ subcommandParser1 =
     { Cli.weave <-
         d: Opt.maybeU64 { short: "d", help: "A non-overlapping subcommand flag with s2." },
         volume: Opt.maybeU64 { short: "v", long: "volume", help: "How loud to grind the gears." },
-        sc: Subcommand.optional [subSubcommandParser1, subSubcommandParser2],
+        sc: SubCmd.optional [subSubcommandParser1, subSubcommandParser2],
     }
-    |> Subcommand.finish { name: "s1", description: "A first subcommand.", mapper: S1 }
+    |> SubCmd.finish { name: "s1", description: "A first subcommand.", mapper: S1 }
 
 subcommandParser2 =
     Opt.maybeU64 { short: "d", help: "This doesn't overlap with s1's -d flag." }
     |> Cli.map DFlag
-    |> Subcommand.finish {
+    |> SubCmd.finish {
         name: "s2",
         description: "Another subcommand.",
         mapper: S2,
@@ -62,7 +62,7 @@ subSubcommandParser1 =
         a: Opt.u64 { short: "a", help: "An example short flag for a sub-subcommand." },
         b: Opt.u64 { short: "b", help: "Another example short flag for a sub-subcommand." },
     }
-    |> Subcommand.finish { name: "ss1", description: "A sub-subcommand.", mapper: SS1 }
+    |> SubCmd.finish { name: "ss1", description: "A sub-subcommand.", mapper: SS1 }
 
 subSubcommandParser2 =
     { Cli.weave <-
@@ -70,4 +70,4 @@ subSubcommandParser2 =
         c: Opt.u64 { short: "c", long: "create", help: "Create a doohickey." },
         data: Param.str { name: "data", help: "Data to manipulate." },
     }
-    |> Subcommand.finish { name: "ss2", description: "Another sub-subcommand.", mapper: SS2 }
+    |> SubCmd.finish { name: "ss2", description: "Another sub-subcommand.", mapper: SS2 }

--- a/package/Base.roc
+++ b/package/Base.roc
@@ -13,14 +13,19 @@ module [
     Plurality,
     SpecialFlags,
     InvalidValue,
+    DefaultValue,
     ValueParser,
     OptionConfigBaseParams,
+    DefaultableOptionConfigBaseParams,
     OptionConfigParams,
+    DefaultableOptionConfigParams,
     OptionConfig,
     helpOption,
     versionOption,
     ParameterConfigBaseParams,
+    DefaultableParameterConfigBaseParams,
     ParameterConfigParams,
+    DefaultableParameterConfigParams,
     ParameterConfig,
     CliConfigParams,
     CliConfig,
@@ -110,6 +115,8 @@ SpecialFlags : { help : Bool, version : Bool }
 
 InvalidValue : [InvalidNumStr, InvalidValue Str]
 
+DefaultValue a : [NoDefault, Value a, Generate ({} -> a)]
+
 ## A parser that extracts an argument value from a string.
 ValueParser a : Str -> Result a InvalidValue
 
@@ -119,6 +126,13 @@ OptionConfigBaseParams : {
     help ? Str,
 }
 
+DefaultableOptionConfigBaseParams a : {
+    short ? Str,
+    long ? Str,
+    help ? Str,
+    default ? DefaultValue a,
+}
+
 ## Default-value options for creating an option.
 OptionConfigParams a : {
     short ? Str,
@@ -126,6 +140,16 @@ OptionConfigParams a : {
     help ? Str,
     type : Str,
     parser : ValueParser a,
+}
+
+## Default-value options for creating an option.
+DefaultableOptionConfigParams a : {
+    short ? Str,
+    long ? Str,
+    help ? Str,
+    type : Str,
+    parser : ValueParser a,
+    default ? DefaultValue a,
 }
 
 ## Metadata for options in our CLI building system.
@@ -162,12 +186,27 @@ ParameterConfigBaseParams : {
     help ? Str,
 }
 
+DefaultableParameterConfigBaseParams a : {
+    name : Str,
+    help ? Str,
+    default ? DefaultValue a,
+}
+
 ## Default-value options for creating an parameter.
 ParameterConfigParams a : {
     name : Str,
     help ? Str,
     type : Str,
     parser : ValueParser a,
+}
+
+## Default-value options for creating an parameter.
+DefaultableParameterConfigParams a : {
+    name : Str,
+    help ? Str,
+    type : Str,
+    parser : ValueParser a,
+    default ? DefaultValue a,
 }
 
 ## Metadata for parameters in our CLI building system.

--- a/package/Builder.roc
+++ b/package/Builder.roc
@@ -89,11 +89,11 @@ setParser = \@CliBuilder builder, parser ->
 updateParser : CliBuilder state fromAction toAction, ({ data : state, remainingArgs : List Arg } -> Result { data : nextState, remainingArgs : List Arg } ArgExtractErr) -> CliBuilder nextState fromAction toAction
 updateParser = \@CliBuilder builder, updater ->
     newParser =
-        { data, remainingArgs, subcommandPath } <- onSuccessfulArgParse builder.parser
-        when updater { data, remainingArgs } is
-            Err err -> IncorrectUsage err { subcommandPath }
-            Ok { data: updatedData, remainingArgs: restOfArgs } ->
-                SuccessfullyParsed { data: updatedData, remainingArgs: restOfArgs, subcommandPath }
+        onSuccessfulArgParse builder.parser \{ data, remainingArgs, subcommandPath } ->
+            when updater { data, remainingArgs } is
+                Err err -> IncorrectUsage err { subcommandPath }
+                Ok { data: updatedData, remainingArgs: restOfArgs } ->
+                    SuccessfullyParsed { data: updatedData, remainingArgs: restOfArgs, subcommandPath }
 
     setParser (@CliBuilder builder) newParser
 
@@ -101,8 +101,8 @@ bindParser : CliBuilder state fromAction toAction, (ArgParserState state -> ArgP
 bindParser = \@CliBuilder builder, updater ->
     newParser : ArgParser nextState
     newParser =
-        { data, remainingArgs, subcommandPath } <- onSuccessfulArgParse builder.parser
-        updater { data, remainingArgs, subcommandPath }
+        onSuccessfulArgParse builder.parser \{ data, remainingArgs, subcommandPath } ->
+            updater { data, remainingArgs, subcommandPath }
 
     setParser (@CliBuilder builder) newParser
 

--- a/package/Cli.roc
+++ b/package/Cli.roc
@@ -1,9 +1,9 @@
-## Weave together a CLI parser using the `<- ` builder notation!
+## Weave together a CLI parser using the `<-` builder notation!
 ##
 ## This module is the entry point for creating CLIs using Weaver.
 ## To get started, call the [weave] method and pass a
 ## [record builder](https://www.roc-lang.org/examples/RecordBuilder/README.html)
-## to it. You can pass `Opt`s, `Param`s, or `Subcommand`s as fields,
+## to it. You can pass `Opt`s, `Param`s, or `SubCmd`s as fields,
 ## and Weaver will automatically register them in its config as
 ## well as build a parser with the inferred types of the fields
 ## you set.
@@ -28,7 +28,7 @@
 ## ```roc
 ## fooSubcommand =
 ##     Opt.u64 { short: "a", help: "Set the alpha level" }
-##     |> Subcommand.finish {
+##     |> SubCmd.finish {
 ##         name: "foo",
 ##         description: "Foo some stuff."
 ##         mapper: Foo,
@@ -38,7 +38,7 @@
 ##     # We allow two subcommands of the same parent to have overlapping
 ##     # fields since only one can ever be parsed at a time.
 ##     Opt.u64 { short: "a", help: "Set the alpha level" }
-##     |> Subcommand.finish {
+##     |> SubCmd.finish {
 ##         name: "bar",
 ##         description: "Bar some stuff."
 ##         mapper: Bar,
@@ -46,7 +46,7 @@
 ##
 ## { Cli.weave <-
 ##     verbosity: Opt.count { short: "v", long: "verbose" },
-##     sc: Subcommand.optional [fooSubcommand, barSubcommand],
+##     sc: SubCmd.optional [fooSubcommand, barSubcommand],
 ## }
 ## ```
 ##
@@ -85,8 +85,8 @@
 ## If you want to see more examples, check the [examples](https://github.com/smores56/weaver/tree/main/examples)
 ## folder in the [repository](https://github.com/smores56/weaver).
 ##
-## _note: `Opt`s must be set before an optional `Subcommand` field is given,_
-## _and the `Subcommand` field needs to be set before `Param`s are set._
+## _note: `Opt`s must be set before an optional `SubCmd` field is given,_
+## _and the `SubCmd` field needs to be set before `Param`s are set._
 ## _`Param` lists also cannot be followed by anything else including_
 ## _themselves. These requirements ensure we parse arguments in the_
 ## _right order. Luckily, all of this is ensured at the type level._
@@ -149,7 +149,7 @@ map : CliBuilder a fromAction toAction, (a -> b) -> CliBuilder b fromAction toAc
 map = \builder, mapper ->
     Builder.map builder mapper
 
-## Begin weaving together a CLI builder using the `<- ` builder notation.
+## Begin weaving together a CLI builder using the `<-` builder notation.
 ##
 ## Check the module-level documentation for general usage instructions.
 ##

--- a/package/Param.roc
+++ b/package/Param.roc
@@ -54,7 +54,9 @@ import Builder exposing [
 import Base exposing [
     ArgExtractErr,
     ParameterConfigBaseParams,
+    DefaultableParameterConfigBaseParams,
     ParameterConfigParams,
+    DefaultableParameterConfigParams,
     ParameterConfig,
     strTypeName,
     numTypeName,
@@ -112,13 +114,19 @@ builderWithParameterParser = \param, valueParser ->
 ##     parser ["example", "blue"]
 ##     == SuccessfullyParsed Blue
 ## ```
-single : ParameterConfigParams state -> CliBuilder state {}action GetParamsAction
-single = \{ parser, type, name, help ? "" } ->
+single : DefaultableParameterConfigParams data -> CliBuilder data {}action GetParamsAction
+single = \{ parser, type, name, help ? "", default ? NoDefault } ->
     param = { name, type, help, plurality: One }
+
+    defaultGenerator = \{} ->
+        when default is
+            Value defaultValue -> Ok defaultValue
+            Generate generator -> Ok (generator {})
+            NoDefault -> Err (MissingParam param)
 
     valueParser = \values ->
         when List.first values is
-            Err ListWasEmpty -> Err (MissingParam param)
+            Err ListWasEmpty -> defaultGenerator {}
             Ok singleValue ->
                 parser singleValue
                 |> Result.mapErr \err -> InvalidParamValue err param
@@ -236,8 +244,8 @@ list = \{ parser, type, name, help ? "" } ->
 ##     parser ["example", "abc"]
 ##     == SuccessfullyParsed "abc"
 ## ```
-str : ParameterConfigBaseParams -> CliBuilder Str {}action GetParamsAction
-str = \{ name, help ? "" } -> single { parser: Ok, type: strTypeName, name, help }
+str : DefaultableParameterConfigBaseParams Str -> CliBuilder Str {}action GetParamsAction
+str = \{ name, help ? "", default ? NoDefault } -> single { parser: Ok, type: strTypeName, name, help, default }
 
 ## Add an optional string parameter to your CLI builder.
 ##
@@ -289,8 +297,8 @@ strList = \{ name, help ? "" } -> list { parser: Ok, type: strTypeName, name, he
 ##     parser ["example", "42.5"]
 ##     == SuccessfullyParsed 42.5
 ## ```
-dec : ParameterConfigBaseParams -> CliBuilder Dec {}action GetParamsAction
-dec = \{ name, help ? "" } -> single { parser: Str.toDec, type: numTypeName, name, help }
+dec : DefaultableParameterConfigBaseParams Dec -> CliBuilder Dec {}action GetParamsAction
+dec = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toDec, type: numTypeName, name, help, default }
 
 ## Add an optional `Dec` parameter to your CLI builder.
 ##
@@ -343,8 +351,8 @@ decList = \{ name, help ? "" } -> list { parser: Str.toDec, type: numTypeName, n
 ##     parser ["example", "42.5"]
 ##     == SuccessfullyParsed 42.5
 ## ```
-f32 : ParameterConfigBaseParams -> CliBuilder F32 {}action GetParamsAction
-f32 = \{ name, help ? "" } -> single { parser: Str.toF32, type: numTypeName, name, help }
+f32 : DefaultableParameterConfigBaseParams F32 -> CliBuilder F32 {}action GetParamsAction
+f32 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toF32, type: numTypeName, name, help, default }
 
 ## Add an optional `F32` parameter to your CLI builder.
 ##
@@ -397,8 +405,8 @@ f32List = \{ name, help ? "" } -> list { parser: Str.toF32, type: numTypeName, n
 ##     parser ["example", "42.5"]
 ##     == SuccessfullyParsed 42.5
 ## ```
-f64 : ParameterConfigBaseParams -> CliBuilder F64 {}action GetParamsAction
-f64 = \{ name, help ? "" } -> single { parser: Str.toF64, type: numTypeName, name, help }
+f64 : DefaultableParameterConfigBaseParams F64 -> CliBuilder F64 {}action GetParamsAction
+f64 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toF64, type: numTypeName, name, help, default }
 
 ## Add an optional `F64` parameter to your CLI builder.
 ##
@@ -451,8 +459,8 @@ f64List = \{ name, help ? "" } -> list { parser: Str.toF64, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-u8 : ParameterConfigBaseParams -> CliBuilder U8 {}action GetParamsAction
-u8 = \{ name, help ? "" } -> single { parser: Str.toU8, type: numTypeName, name, help }
+u8 : DefaultableParameterConfigBaseParams U8 -> CliBuilder U8 {}action GetParamsAction
+u8 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toU8, type: numTypeName, name, help, default }
 
 ## Add an optional `U8` parameter to your CLI builder.
 ##
@@ -505,8 +513,8 @@ u8List = \{ name, help ? "" } -> list { parser: Str.toU8, type: numTypeName, nam
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-u16 : ParameterConfigBaseParams -> CliBuilder U16 {}action GetParamsAction
-u16 = \{ name, help ? "" } -> single { parser: Str.toU16, type: numTypeName, name, help }
+u16 : DefaultableParameterConfigBaseParams U16 -> CliBuilder U16 {}action GetParamsAction
+u16 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toU16, type: numTypeName, name, help, default }
 
 ## Add an optional `U16` parameter to your CLI builder.
 ##
@@ -559,8 +567,8 @@ u16List = \{ name, help ? "" } -> list { parser: Str.toU16, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-u32 : ParameterConfigBaseParams -> CliBuilder U32 {}action GetParamsAction
-u32 = \{ name, help ? "" } -> single { parser: Str.toU32, type: numTypeName, name, help }
+u32 : DefaultableParameterConfigBaseParams U32 -> CliBuilder U32 {}action GetParamsAction
+u32 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toU32, type: numTypeName, name, help, default }
 
 ## Add an optional `U32` parameter to your CLI builder.
 ##
@@ -613,8 +621,8 @@ u32List = \{ name, help ? "" } -> list { parser: Str.toU32, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-u64 : ParameterConfigBaseParams -> CliBuilder U64 {}action GetParamsAction
-u64 = \{ name, help ? "" } -> single { parser: Str.toU64, type: numTypeName, name, help }
+u64 : DefaultableParameterConfigBaseParams U64 -> CliBuilder U64 {}action GetParamsAction
+u64 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toU64, type: numTypeName, name, help, default }
 
 ## Add an optional `U64` parameter to your CLI builder.
 ##
@@ -667,8 +675,8 @@ u64List = \{ name, help ? "" } -> list { parser: Str.toU64, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-u128 : ParameterConfigBaseParams -> CliBuilder U128 {}action GetParamsAction
-u128 = \{ name, help ? "" } -> single { parser: Str.toU128, type: numTypeName, name, help }
+u128 : DefaultableParameterConfigBaseParams U128 -> CliBuilder U128 {}action GetParamsAction
+u128 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toU128, type: numTypeName, name, help, default }
 
 ## Add an optional `U128` parameter to your CLI builder.
 ##
@@ -721,8 +729,8 @@ u128List = \{ name, help ? "" } -> list { parser: Str.toU128, type: numTypeName,
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-i8 : ParameterConfigBaseParams -> CliBuilder I8 {}action GetParamsAction
-i8 = \{ name, help ? "" } -> single { parser: Str.toI8, type: numTypeName, name, help }
+i8 : DefaultableParameterConfigBaseParams I8 -> CliBuilder I8 {}action GetParamsAction
+i8 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toI8, type: numTypeName, name, help, default }
 
 ## Add an optional `I8` parameter to your CLI builder.
 ##
@@ -775,8 +783,8 @@ i8List = \{ name, help ? "" } -> list { parser: Str.toI8, type: numTypeName, nam
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-i16 : ParameterConfigBaseParams -> CliBuilder I16 {}action GetParamsAction
-i16 = \{ name, help ? "" } -> single { parser: Str.toI16, type: numTypeName, name, help }
+i16 : DefaultableParameterConfigBaseParams I16 -> CliBuilder I16 {}action GetParamsAction
+i16 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toI16, type: numTypeName, name, help, default }
 
 ## Add an optional `I16` parameter to your CLI builder.
 ##
@@ -829,8 +837,8 @@ i16List = \{ name, help ? "" } -> list { parser: Str.toI16, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-i32 : ParameterConfigBaseParams -> CliBuilder I32 {}action GetParamsAction
-i32 = \{ name, help ? "" } -> single { parser: Str.toI32, type: numTypeName, name, help }
+i32 : DefaultableParameterConfigBaseParams I32 -> CliBuilder I32 {}action GetParamsAction
+i32 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toI32, type: numTypeName, name, help, default }
 
 ## Add an optional `I32` parameter to your CLI builder.
 ##
@@ -883,8 +891,8 @@ i32List = \{ name, help ? "" } -> list { parser: Str.toI32, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-i64 : ParameterConfigBaseParams -> CliBuilder I64 {}action GetParamsAction
-i64 = \{ name, help ? "" } -> single { parser: Str.toI64, type: numTypeName, name, help }
+i64 : DefaultableParameterConfigBaseParams I64 -> CliBuilder I64 {}action GetParamsAction
+i64 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toI64, type: numTypeName, name, help, default }
 
 ## Add an optional `I64` parameter to your CLI builder.
 ##
@@ -937,8 +945,8 @@ i64List = \{ name, help ? "" } -> list { parser: Str.toI64, type: numTypeName, n
 ##     parser ["example", "42"]
 ##     == SuccessfullyParsed 42
 ## ```
-i128 : ParameterConfigBaseParams -> CliBuilder I128 {}action GetParamsAction
-i128 = \{ name, help ? "" } -> single { parser: Str.toI128, type: numTypeName, name, help }
+i128 : DefaultableParameterConfigBaseParams I128 -> CliBuilder I128 {}action GetParamsAction
+i128 = \{ name, help ? "", default ? NoDefault } -> single { parser: Str.toI128, type: numTypeName, name, help, default }
 
 ## Add an optional `I128` parameter to your CLI builder.
 ##

--- a/package/SubCmd.roc
+++ b/package/SubCmd.roc
@@ -36,7 +36,7 @@ SubcommandParserConfig subState : {
 ##         foo: Opt.str { short: "f" },
 ##         bar: Opt.str { short: "b" },
 ##     }
-##     |> Subcommand.finish { name: "foobar", description: "Foo and bar subcommand", mapper: FooBar }
+##     |> SubCmd.finish { name: "foobar", description: "Foo and bar subcommand", mapper: FooBar }
 ## ```
 finish : CliBuilder state fromAction toAction, { name : Str, description ? Str, mapper : state -> commonState } -> { name : Str, parser : ArgParser commonState, config : SubcommandConfig }
 finish = \builder, { name, description ? "", mapper } ->
@@ -95,14 +95,14 @@ getFirstArgToCheckForSubcommandCall = \{ remainingArgs, subcommandPath }, subcom
 ## expect
 ##     fooSubcommand =
 ##         Opt.str { short: "f" }
-##         |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
+##         |> SubCmd.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
 ##
 ##     barSubcommand =
 ##         Opt.str { short: "b" }
-##         |> Subcommand.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
+##         |> SubCmd.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
 ##
 ##     { parser } =
-##         Subcommand.optional [fooSubcommand, barSubcommand],
+##         SubCmd.optional [fooSubcommand, barSubcommand],
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##
@@ -154,14 +154,14 @@ optional = \subcommandConfigs ->
 ## expect
 ##     fooSubcommand =
 ##         Opt.str { short: "f" }
-##         |> Subcommand.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
+##         |> SubCmd.finish { name: "foo", description: "Foo subcommand", mapper: Foo }
 ##
 ##     barSubcommand =
 ##         Opt.str { short: "b" }
-##         |> Subcommand.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
+##         |> SubCmd.finish { name: "bar", description: "Bar subcommand", mapper: Bar }
 ##
 ##     { parser } =
-##         Subcommand.required [fooSubcommand, barSubcommand],
+##         SubCmd.required [fooSubcommand, barSubcommand],
 ##         |> Cli.finish { name: "example" }
 ##         |> Cli.assertValid
 ##

--- a/package/main.roc
+++ b/package/main.roc
@@ -5,6 +5,6 @@ package [
     ErrorFormatter,
     Help,
     Param,
-    Subcommand,
+    SubCmd,
     Validate,
 ] {}


### PR DESCRIPTION
Support default values for options and parameters via a `default ? [NoDefault, Value a, Generate ({} -> a)]` field for single value fields (e.g. `str`, `dec`, etc.).

The thing I wanted to add but couldn't find a good way to do it was help text support. I could require the default type to implement `Inspect`, but that wouldn't even work for the `Generate ({} -> a)` variant of `default` since it's not known ahead of time. So for now the expectation is that the arg's help text is given a `default: xyz` suffix.

@isaacvando does this look good to you? I can make a release if so.