### PR TITLE
Upgrade to use purity inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,26 @@ Read the documentation at <https://smores56.github.io/weaver/Cli/>.
 
 ## Status
 
-This library should be ready for usage already, but I'm always looking for more testing
+This library is ready to parse your args today, but I'm always looking for more testing
 from the community! Feel free to open a GitHub issue if there's a feature you're missing
 from another CLI parsing library that you think would fit well in Weaver's nest.
 
 ## Example
 
 ```roc
-app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
-    weaver: "https://github.com/smores56/weaver/releases/download/0.3.1/CZWzZ3WIfkG5_rxdcwPQ0PqgrlZQFwKQUi2zyMYddXc.tar.br",
+app [main!] {
+    pf: platform "<latest from https://github.com/roc-lang/basic-cli/releases>",
+    weaver: "<latest from https://github.com/smores56/weaver/releases>",
 }
 
-import pf.Stdout
 import pf.Arg
-import pf.Task exposing [Task]
+import pf.Stdout
 import weaver.Opt
 import weaver.Cli
 import weaver.Param
 
-main =
-    args = Arg.list!
+main! = \{} ->
+    args = Arg.list! {}
 
     when Cli.parseOrDisplayMessage cliParser args is
         Ok data ->
@@ -44,7 +43,7 @@ main =
         Err message ->
             Stdout.line! message
 
-            Task.err (Exit 1 "")
+            Err (Exit 1 "")
 
 cliParser =
     { Cli.weave <-
@@ -90,17 +89,16 @@ Options:
   -V, --version  Show the version.
 ```
 
-There are also some examples in the [examples](./examples) directory that are more feature-complete,
-with more to come as this library matures.
+There are also some examples in the [examples](./examples) directory that are more
+feature-complete, with more to come as this library matures.
 
 ## Roadmap
 
 Now that an initial release has happened, these are some ideas I have for future development:
 
-- [X] Set default values in the arguments themselves (Handled with Cli.map and Result.withDefault)
-- [ ] Optionally set `{ group : Str }` per option so they are visually grouped in the help page
+- [ ] Optionally set `{ group ? Str }` per option so they are visually grouped in the help page
 - [ ] Completion generation for popular shells (e.g. Bash, Zsh, Fish, etc.)
-- [X] Add terminal escape sequences to generated messages for prettier help/usage text formatting
-- [ ] add convenient `Task` helpers (e.g. parse or print help and exit) once [module params](https://docs.google.com/document/u/0/d/110MwQi7Dpo1Y69ECFXyyvDWzF4OYv1BLojIm08qDTvg) land
+- [X] Add terminal escape sequences to generated messages for prettier help/usage text formatting (currently working, but could be nicer/more configurable)
+- [ ] add convenient CLI platform wrappers (e.g. parse, or print help and exit) for use with module params
 - [X] Clean up default parameter code if we can elide different fields on the same record type in different places (not currently allowed)
 - [ ] Add more testing (always)

--- a/examples/basic.roc
+++ b/examples/basic.roc
@@ -1,17 +1,16 @@
-app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+app [main!] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.17.0/lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE.tar.br",
     weaver: "../package/main.roc",
 }
 
-import pf.Stdout
 import pf.Arg
-import pf.Task exposing [Task]
+import pf.Stdout
 import weaver.Opt
 import weaver.Cli
 import weaver.Param
 
-main =
-    args = Arg.list!
+main! = \{} ->
+    args = Arg.list! {}
 
     when Cli.parseOrDisplayMessage cliParser args is
         Ok data ->
@@ -22,7 +21,7 @@ main =
         Err message ->
             Stdout.line! message
 
-            Task.err (Exit 1 "")
+            Err (Exit 1 "")
 
 cliParser =
     { Cli.weave <-

--- a/examples/default-values.roc
+++ b/examples/default-values.roc
@@ -1,17 +1,16 @@
-app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+app [main!] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.17.0/lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE.tar.br",
     weaver: "../package/main.roc",
 }
 
-import pf.Stdout
 import pf.Arg
-import pf.Task exposing [Task]
+import pf.Stdout
 import weaver.Opt
 import weaver.Cli
 import weaver.Param
 
-main =
-    args = Arg.list!
+main! = \{} ->
+    args = Arg.list! {}
 
     when Cli.parseOrDisplayMessage cliParser args is
         Ok data ->
@@ -22,7 +21,7 @@ main =
         Err message ->
             Stdout.line! message
 
-            Task.err (Exit 1 "")
+            Err (Exit 1 "")
 
 cliParser =
     { Cli.weave <-

--- a/examples/single-arg.roc
+++ b/examples/single-arg.roc
@@ -1,16 +1,15 @@
-app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+app [main!] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.17.0/lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE.tar.br",
     weaver: "../package/main.roc",
 }
 
-import pf.Stdout
 import pf.Arg
-import pf.Task exposing [Task]
+import pf.Stdout
 import weaver.Opt
 import weaver.Cli
 
-main =
-    args = Arg.list!
+main! = \{} ->
+    args = Arg.list! {}
 
     when Cli.parseOrDisplayMessage cliParser args is
         Ok data ->
@@ -21,7 +20,7 @@ main =
         Err message ->
             Stdout.line! message
 
-            Task.err (Exit 1 "")
+            Err (Exit 1 "")
 
 cliParser =
     Opt.u64 { short: "a", long: "alpha", help: "Set the alpha level." }

--- a/examples/subcommands.roc
+++ b/examples/subcommands.roc
@@ -1,18 +1,17 @@
-app [main] {
-    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+app [main!] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.17.0/lZFLstMUCUvd5bjnnpYromZJXkQUrdhbva4xdBInicE.tar.br",
     weaver: "../package/main.roc",
 }
 
-import pf.Stdout
 import pf.Arg
-import pf.Task exposing [Task]
+import pf.Stdout
 import weaver.Opt
 import weaver.Cli
 import weaver.Param
 import weaver.SubCmd
 
-main =
-    args = Arg.list!
+main! = \{} ->
+    args = Arg.list! {}
 
     when Cli.parseOrDisplayMessage cliParser args is
         Ok data ->
@@ -23,7 +22,7 @@ main =
         Err message ->
             Stdout.line! message
 
-            Task.err (Exit 1 "")
+            Err (Exit 1 "")
 
 cliParser =
     { Cli.weave <-

--- a/package/Help.roc
+++ b/package/Help.roc
@@ -339,7 +339,7 @@ indentMultilineStringBy = \string, indentAmount ->
     indentation = Str.repeat " " indentAmount
 
     string
-    |> Str.split "\n"
+    |> Str.splitOn "\n"
     |> List.mapWithIndex \line, index ->
         if index == 0 then
             line

--- a/package/Opt.roc
+++ b/package/Opt.roc
@@ -66,10 +66,8 @@ import Parser exposing [ArgValue]
 builderWithOptionParser : OptionConfig, (List ArgValue -> Result data ArgExtractErr) -> CliBuilder data fromAction toAction
 builderWithOptionParser = \option, valueParser ->
     argParser = \args ->
-        { values, remainingArgs } <- extractOptionValues { args, option }
-            |> Result.try
-        data <- valueParser values
-            |> Result.try
+        { values, remainingArgs } = try extractOptionValues { args, option }
+        data = try valueParser values
 
         Ok { data, remainingArgs }
 
@@ -124,8 +122,7 @@ single = \{ parser, type, short ? "", long ? "", help ? "", default ? NoDefault 
             NoDefault -> Err (MissingOption option)
 
     valueParser = \values ->
-        value <- getMaybeValue values option
-            |> Result.try
+        value = try getMaybeValue values option
 
         when value is
             Err NoValue -> defaultGenerator {}
@@ -172,8 +169,7 @@ maybe = \{ parser, type, short ? "", long ? "", help ? "" } ->
     option = { expectedValue: ExpectsValue type, plurality: Optional, short, long, help }
 
     valueParser = \values ->
-        value <- getMaybeValue values option
-            |> Result.try
+        value = try getMaybeValue values option
 
         when value is
             Err NoValue -> Ok (Err NoValue)
@@ -250,8 +246,7 @@ flag = \{ short ? "", long ? "", help ? "" } ->
     option = { expectedValue: NothingExpected, plurality: Optional, short, long, help }
 
     valueParser = \values ->
-        value <- getMaybeValue values option
-            |> Result.try
+        value = try getMaybeValue values option
 
         when value is
             Err NoValue -> Ok Bool.false

--- a/package/Param.roc
+++ b/package/Param.roc
@@ -67,10 +67,8 @@ import Extract exposing [extractParamValues]
 builderWithParameterParser : ParameterConfig, (List Str -> Result data ArgExtractErr) -> CliBuilder data fromAction toAction
 builderWithParameterParser = \param, valueParser ->
     argParser = \args ->
-        { values, remainingArgs } <- extractParamValues { args, param }
-            |> Result.try
-        data <- valueParser values
-            |> Result.try
+        { values, remainingArgs } = try extractParamValues { args, param }
+        data = try valueParser values
 
         Ok { data, remainingArgs }
 


### PR DESCRIPTION
Purity inference [has been merged](https://github.com/roc-lang/roc/pull/7170), so once the `return` fix is ready in [this PR](https://github.com/roc-lang/roc/pull/7204), we can validate this PR and then merge.